### PR TITLE
Redirect to correct URLs when resolving dynamic links

### DIFF
--- a/app/src/routes/explore/[link].ts
+++ b/app/src/routes/explore/[link].ts
@@ -1,15 +1,28 @@
+import type { RequestHandlerOutput } from '@sveltejs/kit'
+
 import { content } from '$lib/content-backend'
 import { getToolByLink } from '$lib/content-utils'
 
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function get({ params: { link } }: { params: { link: string } }) {
+export async function get({
+    params: { link },
+}: {
+    params: Record<string, string>
+}) {
     const tool = getToolByLink(link, content)
 
     if (tool) {
-        return { body: { tool, content } }
+        return {
+            body: { tool, content },
+            // If page was found on a different URL,
+            // permanently redirect to the updated url (HTTP 301)
+            // to prevent multiple URLs publishing the same content.
+            status: link === tool.link ? 200 : 301,
+            headers: {
+                location: `/explore/${tool.link}`,
+            },
+        } as RequestHandlerOutput
     }
 
-    return {
-        status: 404,
-    }
+    return { status: 404 }
 }


### PR DESCRIPTION
Prevent multiple URLs publishing the same content by redirecting to the actual URL, while still serving the content as expected.

This hopefully reduces the risk that redirects negatively impact SEO