### PR TITLE
Allow some internal links to disable scrolling

### DIFF
--- a/shared/components/Link.svelte
+++ b/shared/components/Link.svelte
@@ -22,6 +22,11 @@
     export let tabindex: number | undefined = undefined
     export let title: string | undefined = undefined
 
+    /**
+     * Disable scrolling on navigation. This only makes sense for internal links.
+     */
+    export let noScroll: boolean = false
+
     let additionalProps: object
     onMount(() => {
         if (isExternalURL(href)) {
@@ -29,6 +34,10 @@
                 rel: 'noopener noreferrer',
                 target: '_blank',
                 'data-sveltekit-reload': true,
+            }
+        } else if (noScroll) {
+            additionalProps = {
+                'data-sveltekit-noscroll': true,
             }
         }
     })

--- a/shared/components/LocaleSwitcher.svelte
+++ b/shared/components/LocaleSwitcher.svelte
@@ -29,6 +29,7 @@
                 <Link
                     href={getLocalisedPath(locale, pathname)}
                     variant="black"
+                    noScroll
                     on:click={() => {
                         open = false
                     }}


### PR DESCRIPTION
This is a much smoother UX for the framework page